### PR TITLE
CHORE: bump utilities for new accelDataSupport

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.1.4
+
+### Enhancements
+
+* Bump `openbci-utilities` to v0.2.0 for accelDataCounts support on cyton.
+
 # 0.1.3
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-wifi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The official wifi package of Node.js SDK for the OpenBCI/Push The World Wifi SHeild for Biosensor Boards.",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "ip": "^1.1.5",
     "lodash": "^4.16.6",
     "node-ssdp": "^3.2.1",
-    "openbci-utilities": "^0.1.5",
+    "openbci-utilities": "^0.2.0",
     "safe-buffer": "^5.1.1"
   },
   "directories": {


### PR DESCRIPTION
# 0.1.4

### Enhancements

* Bump `openbci-utilities` to v0.2.0 for accelDataCounts support on cyton.